### PR TITLE
fix: report neutral status when webhook verification errors

### DIFF
--- a/crates/server/src/webhook.rs
+++ b/crates/server/src/webhook.rs
@@ -208,7 +208,7 @@ async fn handle_pull_request(state: WebhookState, payload: serde_json::Value) {
                     &repo,
                     &head_sha,
                     "metsuke / verify-pr",
-                    "failure",
+                    "neutral",
                     "Verification Error",
                     &format!("Failed to run verification: {e}"),
                 )


### PR DESCRIPTION
## Summary
- Webhook-triggered `verify_pr` errors (missing policy file, API failure, etc.) previously produced a `failure` check run, blocking PRs for reasons unrelated to policy compliance.
- Changed the error path in `webhook.rs:211` to report `neutral` instead, so the error is surfaced via the check run output without failing the PR.

## Context
Unchanged:
- Successful runs still use the `fail_count > 0 ? failure : success` logic in `format_check_result` (`webhook.rs:385`).
- Review findings continue to map to `success` (unchanged; that was option B, not requested here).

## Test plan
- [ ] Trigger a PR webhook against a repo where `verify_pr` errors → check run should appear as `neutral` with title `Verification Error`.
- [ ] Trigger a PR webhook against a repo with a valid policy and no failing controls → check run should still be `success`.
- [ ] Trigger a PR webhook with failing controls → check run should still be `failure`.

https://claude.ai/code/session_01JqK6NoZmrEs97Ws97YNysL