### PR TITLE
chore: add cargo and npm ecosystems to dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- `.github/dependabot.yaml` が `github-actions` のみを対象としていたため、Rust (Cargo) / npm の依存関係更新が自動化されていませんでした
- `cargo` と `npm` エコシステムを追加し、脆弱性に対して Dependabot が自動PRを作成できるようにしました

## 背景

現在 27 件の open security alert があります（一部）:
- `openssl` (Rust) x8 (high/medium/low): buffer overflow, UB, memory issues
- `rustls-webpki` x3 (high/low): DoS, wildcard name constraint bypass
- `hono` x6 (high/medium/low): HTML injection, JWT bypass, cache leakage
- `jsonwebtoken` (medium): type confusion auth bypass
- `rmcp` (high): DNS rebinding
- `rand` x2 (low): unsound with custom logger

## Test plan

- [ ] PR マージ後に Dependabot が cargo / npm エコシステムに対して PR を作成することを確認