### PR TITLE
fix(deps): bump openssl and rustls-webpki to fix multiple HIGH CVEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1532,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "libverify-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fd5173373b6cd059683bc40a2835337b70c36c76cffbdf396edd51de8e5539"
+checksum = "4bf04fe144de878aa573e9ba3ac116f8b9ec2a7805f28414e6dc6a522d0443b5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1552,14 +1552,14 @@ dependencies = [
 
 [[package]]
 name = "libverify-github"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e838a6cc5bac4609f22f009273a49fbadb01c3cb9e514079edc9de1d8531ad20"
+checksum = "a16e505559538660fca0975a56894e7d838f766b916f0e3898832455305e299b"
 dependencies = [
  "anyhow",
  "base64",
- "libverify-core 0.11.0",
- "libverify-policy 0.11.0",
+ "libverify-core 0.12.0",
+ "libverify-policy 0.12.0",
  "p256",
  "reqwest 0.13.1",
  "serde",
@@ -1571,12 +1571,12 @@ dependencies = [
 
 [[package]]
 name = "libverify-policy"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a173addff593bb725a6427cf6f2b4194cb1dff55d1192809bc3548065a6f8ee6"
+checksum = "84a731b5d0c54f40e9a3bb2c2b0990dd551746cd3b37d28dc5b861b78fae56b0"
 dependencies = [
  "anyhow",
- "libverify-core 0.11.0",
+ "libverify-core 0.12.0",
  "regorus",
  "serde",
  "serde_json",
@@ -1858,15 +1858,14 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1890,9 +1889,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2552,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## 変更内容

`Cargo.lock` を更新し、openssl と rustls-webpki の脆弱バージョンを解消。

```
cargo update openssl rustls-webpki
```

## 解消されるアラート

| alert | package | severity | before | after |
|---|---|---|---|---|
| #19-23 | `openssl` | HIGH (複数) | 0.10.76 | **0.10.80** ✅ |
| #24 | `rustls-webpki` | HIGH | 0.103.10 | **0.103.13** ✅ |
| #25-27 | `openssl` | HIGH/medium | 0.10.76 | **0.10.80** ✅ |

副作用: `libverify-core/github/policy` 0.11.0 → 0.12.0
(Cargo.toml の `"0.12"` 制約が正しく解決された)

## 検証

`cargo check` でビルド成功を確認済み。